### PR TITLE
Add platformio configuration file to compile the emulation firmware f…

### DIFF
--- a/Emulation/ds2480.c
+++ b/Emulation/ds2480.c
@@ -66,21 +66,21 @@ void serial_flushrx() {
 
 /* ================= 1-wire bus low-level functions ========== */
 
-inline void bus_pull_down() {
+static inline void bus_pull_down() {
 #ifdef WAEK_PULLUP
 	PORT(OWPIN) &= ~BV(OWPIN);
 #endif
 	DDR(OWPIN) |= BV(OWPIN);    // drives output low
 }
 
-inline void bus_release() {
+static inline void bus_release() {
 #ifdef WAEK_PULLUP
 	PORT(OWPIN) |= BV(OWPIN);
 #endif
 	DDR(OWPIN) &= ~BV(OWPIN);
 }
 
-inline uint8_t bus_read() {
+static inline uint8_t bus_read() {
 	return (PIN(OWPIN) & BV(OWPIN)) ? 1 : 0;
 }
 

--- a/Emulation/platformio.ini
+++ b/Emulation/platformio.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = nano
+src_dir = .
+
+[env:nano]
+platform = atmelavr
+board = nanoatmega328
+build_flags = -DOWPIN=B,3
+board_build.f_cpu = 16000000L
+monitor_speed = 9600
+


### PR DESCRIPTION
…or Arduino Nano.

This platformio.ini configuration defines the target hardware and compiler settings to compile the Arduino emulation for Arduino Nano.